### PR TITLE
feat: struct-ify the user object

### DIFF
--- a/lib/statsig.ex
+++ b/lib/statsig.ex
@@ -1,6 +1,6 @@
 defmodule Statsig do
-
   alias Statsig.EvaluationResult
+  alias Statsig.User
 
   defdelegate log_event(event), to: Statsig.Logging
   defdelegate flush(), to: Statsig.Logging
@@ -34,7 +34,7 @@ defmodule Statsig do
     get_config(user, experiment)
   end
 
-  def log_event(user, event_name, value, metadata) do
+  def log_event(%User{} = user, event_name, value, metadata) do
     user = Statsig.Utils.get_user_with_env(user)
 
     event = %{
@@ -48,7 +48,7 @@ defmodule Statsig do
     log_event(event)
   end
 
-  defp log_exposures(user, %EvaluationResult{} = result, :config) do
+  defp log_exposures(%User{} = user, %EvaluationResult{} = result, :config) do
     [exposure | secondary] = result.exposures
 
     primary = %{
@@ -65,9 +65,8 @@ defmodule Statsig do
     log_event(event)
   end
 
-  defp log_exposures(user, %EvaluationResult{} = result, type) do
+  defp log_exposures(%User{} = user, %EvaluationResult{} = result, type) do
     [primary | secondary] = result.exposures
-
     event =
       base_event(user, secondary, type)
       |> Map.put(:metadata, primary)
@@ -75,7 +74,7 @@ defmodule Statsig do
     log_event(event)
   end
 
-  defp base_event(user, secondary, type) do
+  defp base_event(%User{} = user, secondary, type) do
     user = Statsig.Utils.sanitize_user(user)
 
     %{

--- a/lib/statsig.ex
+++ b/lib/statsig.ex
@@ -67,6 +67,7 @@ defmodule Statsig do
 
   defp log_exposures(%User{} = user, %EvaluationResult{} = result, type) do
     [primary | secondary] = result.exposures
+
     event =
       base_event(user, secondary, type)
       |> Map.put(:metadata, primary)

--- a/lib/statsig/evaluator.ex
+++ b/lib/statsig/evaluator.ex
@@ -434,8 +434,7 @@ defmodule Statsig.Evaluator do
   end
 
   defp get_user_field(%User{} = user, prop) do
-    prop = String.downcase(prop)
-    case prop do
+    case String.downcase(prop) do
       "userid" -> user.user_id
       "email" -> user.email
       "ip" -> user.ip
@@ -445,10 +444,7 @@ defmodule Statsig.Evaluator do
       "appversion" -> user.app_version
       _ ->
         # Check custom fields if not found in main user fields
-        case try_get_with_lower(user.custom || %{}, prop) do
-          nil -> try_get_with_lower(user.private_attributes || %{}, prop)
-          found -> found
-        end
+        try_get_with_lower(user.custom || %{}, prop) || try_get_with_lower(user.private_attributes || %{}, prop)
     end
   end
 
@@ -461,10 +457,8 @@ defmodule Statsig.Evaluator do
   end
 
   defp try_get_with_lower(obj, prop) do
-    lower = String.downcase(prop)
-
     case Map.get(obj, prop) do
-      x when x == nil or x == [] or x == "" -> Map.get(obj, lower)
+      x when x == nil -> Map.get(obj, String.downcase(prop))
       x -> x
     end
   end

--- a/lib/statsig/evaluator.ex
+++ b/lib/statsig/evaluator.ex
@@ -425,32 +425,35 @@ defmodule Statsig.Evaluator do
     hash
   end
 
-  defp get_user_id(%User{userID: id}, "userID"), do: to_string(id)
+  defp get_user_id(%User{} = user, "userID"), do: to_string(user.user_id)
 
-  defp get_user_id(%User{customIDs: custom_ids}, prop),
-    do: try_get_with_lower(custom_ids, prop) |> to_string()
+  defp get_user_id(%User{} = user, prop),
+    do: try_get_with_lower(user.custom_ids || %{}, prop) |> to_string()
 
   defp get_user_field(%User{} = user, prop) do
     case try_get_with_lower(%{
-      user.userID => user.userID,
+      user.userID => user.user_id,
       "email" => user.email,
       "ip" => user.ip,
-      "userAgent" => user.userAgent,
+      "userAgent" => user.user_agent,
       "country" => user.country,
       "locale" => user.locale,
-      "appVersion" => user.appVersion
+      "appVersion" => user.app_version
     }, prop) do
       nil -> try_get_with_lower(user.custom || %{}, prop)
       found -> found
     end
     |> case do
-      nil -> try_get_with_lower(user.privateAttributes || %{}, prop)
+      nil -> try_get_with_lower(user.private_attributes || %{}, prop)
       found -> found
     end
   end
 
-  defp get_env_field(%User{statsigEnvironment: env}, field) when not is_nil(env),
-    do: try_get_with_lower(env, field) |> to_string()
+  defp get_env_field(%User{} = user, field) do
+    user.statsig_environment
+    |> Map.get(field)
+    |> to_string()
+  end
 
   defp get_env_field(_, _), do: nil
 

--- a/lib/statsig/evaluator.ex
+++ b/lib/statsig/evaluator.ex
@@ -428,8 +428,8 @@ defmodule Statsig.Evaluator do
   defp get_user_id(%User{} = user, "userID"), do: to_string(user.user_id)
 
   defp get_user_id(%User{} = user, prop) do
-    (user.custom_ids || [])
-    |> Keyword.get(String.to_atom(prop))
+    (user.custom_ids || %{})
+    |> Map.get(prop)
     |> to_string()
   end
 

--- a/lib/statsig/evaluator.ex
+++ b/lib/statsig/evaluator.ex
@@ -434,14 +434,15 @@ defmodule Statsig.Evaluator do
   end
 
   defp get_user_field(%User{} = user, prop) do
+    prop = String.downcase(prop)
     case prop do
-      "userID" -> user.user_id
+      "userid" -> user.user_id
       "email" -> user.email
       "ip" -> user.ip
-      "userAgent" -> user.user_agent
+      "useragent" -> user.user_agent
       "country" -> user.country
       "locale" -> user.locale
-      "appVersion" -> user.app_version
+      "appversion" -> user.app_version
       _ ->
         # Check custom fields if not found in main user fields
         case try_get_with_lower(user.custom || %{}, prop) do

--- a/lib/statsig/evaluator.ex
+++ b/lib/statsig/evaluator.ex
@@ -43,7 +43,7 @@ defmodule Statsig.Evaluator do
       %{
         gate: name,
         gateValue: to_string(result.result),
-        ruleID: Map.get(result.rule, "id"),
+        ruleID: result.rule["id"],
         configVersion: to_string(Map.get(ctx.spec, "version", ""))
       }
       | Enum.reverse(result.exposures)
@@ -53,7 +53,7 @@ defmodule Statsig.Evaluator do
   end
 
   defp do_eval(_user, %Context{spec: %{"enabled" => false, "defaultValue" => default}}),
-    do: %EvaluationResult{value: default, rule: %{id: "disabled"}, reason: :disabled}
+    do: %EvaluationResult{value: default, rule: %{"id" => "disabled"}, reason: :disabled}
 
   defp do_eval(user, %Context{spec: %{"rules" => rules}} = ctx),
     do: eval_rules(user, rules, ctx, [])
@@ -61,7 +61,7 @@ defmodule Statsig.Evaluator do
   defp eval_rules(_user, [], %Context{spec: %{"defaultValue" => default}}, results) do
     Enum.reduce(
       results,
-      %EvaluationResult{result: false, value: default, rule: %{id: "default"}, reason: :no_rule_match},
+      %EvaluationResult{result: false, value: default, rule: %{"id" => "default"}, reason: :no_rule_match},
       fn r, final ->
         %EvaluationResult{final | exposures: r.exposures ++ final.exposures}
       end

--- a/lib/statsig/user.ex
+++ b/lib/statsig/user.ex
@@ -49,11 +49,12 @@ defmodule Statsig.User do
       |> Map.from_struct()
       |> Map.delete(:private_attributes)
       |> Map.update!(:custom_ids, fn custom_ids ->
-        custom_ids && Enum.into(custom_ids, %{})
+        custom_ids && Map.new(custom_ids)
       end)
-      |> Enum.reject(fn {_k, v} -> is_nil(v) end)
-      |> Enum.map(fn {k, v} -> {Statsig.User.encode_as(k), v} end)
-      |> Map.new()
+      |> Enum.reject(&match?({_, nil},&1))
+      |> Map.new(fn {key, value} ->
+        {Statsig.User.encode_as(key), value}
+        end)
       |> Jason.Encode.map(opts)
     end
   end

--- a/lib/statsig/user.ex
+++ b/lib/statsig/user.ex
@@ -1,0 +1,60 @@
+defmodule Statsig.User do
+  @derive {Jason.Encoder, only: [
+    :userID,
+    :customIDs,
+    :email,
+    :ip,
+    :userAgent,
+    :country,
+    :locale,
+    :appVersion,
+    :custom,
+    :statsigEnvironment
+  ]}
+
+  @type custom_value :: String.t() | number() | boolean() | nil
+  @type custom_attributes :: %{optional(String.t()) => custom_value()}
+
+  @type t :: %__MODULE__{
+    userID: String.t() | nil,
+    customIDs: %{optional(String.t()) => String.t()} | nil,
+    email: String.t() | nil,
+    ip: String.t() | nil,
+    userAgent: String.t() | nil,
+    country: String.t() | nil,
+    locale: String.t() | nil,
+    appVersion: String.t() | nil,
+    custom: custom_attributes() | nil,
+    privateAttributes: custom_attributes() | nil,
+    statsigEnvironment: map() | nil
+  }
+
+  defstruct userID: nil,
+            customIDs: nil,
+            email: nil,
+            ip: nil,
+            userAgent: nil,
+            country: nil,
+            locale: nil,
+            appVersion: nil,
+            custom: nil,
+            privateAttributes: nil,
+            statsigEnvironment: nil
+
+  def new(params \\ %{}) do
+    unless Map.get(params, "userID") || Map.get(params, :userID) ||
+           Map.get(params, "customIDs") || Map.get(params, :customIDs) do
+      raise ArgumentError, "Either userID or customIDs must be provided"
+    end
+
+    converted_params = for {key, val} <- params, into: %{} do
+      cond do
+        is_binary(key) -> {String.to_existing_atom(key), val}
+        is_atom(key) -> {key, val}
+        true -> {key, val}
+      end
+    end
+
+    struct(__MODULE__, converted_params)
+  end
+end

--- a/lib/statsig/user.ex
+++ b/lib/statsig/user.ex
@@ -4,7 +4,7 @@ defmodule Statsig.User do
             :ip, :user_agent, :country, :locale, :app_version, :statsig_environment]
 
   @type custom_value :: String.t() | number() | boolean() | nil
-  @type custom_attributes :: %{optional(String.t()) => custom_value()}
+  @type custom_attributes :: %{String.t() => custom_value()}
 
   @type t :: %__MODULE__{
     user_id: String.t() | nil,

--- a/lib/statsig/user.ex
+++ b/lib/statsig/user.ex
@@ -1,60 +1,77 @@
 defmodule Statsig.User do
   @derive {Jason.Encoder, only: [
-    :userID,
-    :customIDs,
+    :user_id,
+    :custom_ids,
     :email,
     :ip,
-    :userAgent,
+    :user_agent,
     :country,
     :locale,
-    :appVersion,
+    :app_version,
     :custom,
-    :statsigEnvironment
+    :statsig_environment
   ]}
 
   @type custom_value :: String.t() | number() | boolean() | nil
   @type custom_attributes :: %{optional(String.t()) => custom_value()}
 
   @type t :: %__MODULE__{
-    userID: String.t() | nil,
-    customIDs: %{optional(String.t()) => String.t()} | nil,
+    user_id: String.t() | nil,
+    custom_ids: %{optional(String.t()) => String.t()} | nil,
     email: String.t() | nil,
     ip: String.t() | nil,
-    userAgent: String.t() | nil,
+    user_agent: String.t() | nil,
     country: String.t() | nil,
     locale: String.t() | nil,
-    appVersion: String.t() | nil,
+    app_version: String.t() | nil,
     custom: custom_attributes() | nil,
-    privateAttributes: custom_attributes() | nil,
-    statsigEnvironment: map() | nil
+    private_attributes: custom_attributes() | nil,
+    statsig_environment: map() | nil
   }
 
-  defstruct userID: nil,
-            customIDs: nil,
-            email: nil,
-            ip: nil,
-            userAgent: nil,
-            country: nil,
-            locale: nil,
-            appVersion: nil,
-            custom: nil,
-            privateAttributes: nil,
-            statsigEnvironment: nil
+  defstruct [
+    :user_id,
+    :custom_ids,
+    :email,
+    :ip,
+    :user_agent,
+    :country,
+    :locale,
+    :app_version,
+    :custom,
+    :private_attributes,
+    :statsig_environment
+  ]
 
-  def new(params \\ %{}) do
-    unless Map.get(params, "userID") || Map.get(params, :userID) ||
-           Map.get(params, "customIDs") || Map.get(params, :customIDs) do
-      raise ArgumentError, "Either userID or customIDs must be provided"
+  def new(user_id_or_custom_ids, params \\ [])
+
+  def new(custom_ids = [_ | _], params) do
+    struct(__MODULE__, Keyword.merge(params, custom_ids: custom_ids))
+  end
+
+  def new(user_id, params) when is_binary(user_id) do
+    struct(__MODULE__, Keyword.merge(params, user_id: user_id))
+  end
+
+  def new(_, _), do: raise("You must provide a user id or custom ids")
+
+  defp new_from_params(params) do
+    params =
+      Keyword.new(params, fn
+        {key, _v} = key_and_value when is_atom(key) -> key_and_value
+        {key, value} when is_binary(key) -> {String.to_existing_atom(key), value}
+      end)
+    struct(__MODULE__, params)
+  end
+
+  def encode_as(key) when is_atom(key) do
+    case key do
+      :user_id -> "userID"
+      :custom_ids -> "customIDs"
+      :user_agent -> "userAgent"
+      :app_version -> "appVersion"
+      :statsig_environment -> "statsigEnvironment"
+      _ -> key |> Atom.to_string()
     end
-
-    converted_params = for {key, val} <- params, into: %{} do
-      cond do
-        is_binary(key) -> {String.to_existing_atom(key), val}
-        is_atom(key) -> {key, val}
-        true -> {key, val}
-      end
-    end
-
-    struct(__MODULE__, converted_params)
   end
 end

--- a/lib/statsig/utils.ex
+++ b/lib/statsig/utils.ex
@@ -1,17 +1,17 @@
 defmodule Statsig.Utils do
   alias Statsig.User
 
-  def get_user_with_env(%User{statsigEnvironment: env} = user) when not is_nil(env),
+  def get_user_with_env(%User{statsig_environment: env} = user) when not is_nil(env),
     do: user
 
-  def get_user_with_env(%User{} = user), do: put_env(user)
+  def get_user_with_env(%User{} = user), do: put_statsig_env(user)
 
-  def sanitize_user(%User{} = user), do: %User{user | privateAttributes: nil}
+  def sanitize_user(%User{} = user), do: %User{user | private_attributes: nil}
 
-  defp put_env(%User{} = user) do
+  defp put_statsig_env(%User{} = user) do
     case Application.get_env(:statsig, :env_tier) do
       nil -> user
-      tier -> %User{user | statsigEnvironment: %{"tier" => tier}}
+      tier -> %User{user | statsig_environment: %{"tier" => tier}}
     end
   end
 end

--- a/lib/statsig/utils.ex
+++ b/lib/statsig/utils.ex
@@ -1,15 +1,17 @@
 defmodule Statsig.Utils do
-  def get_user_with_env(%{"statsigEnvironment" => env} = user) when not is_nil(env),
+  alias Statsig.User
+
+  def get_user_with_env(%User{statsigEnvironment: env} = user) when not is_nil(env),
     do: user
 
-  def get_user_with_env(%{} = user), do: put_env(user)
+  def get_user_with_env(%User{} = user), do: put_env(user)
 
-  def sanitize_user(user), do: Map.delete(user, "privateAttributes")
+  def sanitize_user(%User{} = user), do: %User{user | privateAttributes: nil}
 
-  defp put_env(user) do
+  defp put_env(%User{} = user) do
     case Application.get_env(:statsig, :env_tier) do
       nil -> user
-      tier -> Map.put(user, "statsigEnvironment", %{"tier" => tier})
+      tier -> %User{user | statsigEnvironment: %{"tier" => tier}}
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -14,14 +14,19 @@ defmodule Statsig.MixProject do
 
   # Run "mix help compile.app" to learn about applications.
   def application do
-    [
-      mod: {Statsig.Application, []},
-      extra_applications: [:logger, :jason]
-    ]
+    case Mix.env() do
+      :test ->
+        [extra_applications: [:logger, :jason]]
+      _ ->
+        [
+          mod: {Statsig.Application, []},
+          extra_applications: [:logger, :jason]
+        ]
+    end
   end
 
   # Specifies which paths to compile per environment.
-  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(:test), do: ["lib", "test/support", "test/statsig"]
   defp elixirc_paths(_), do: ["lib"]
 
   # Run "mix help deps" to learn about dependencies.

--- a/mix.exs
+++ b/mix.exs
@@ -14,27 +14,25 @@ defmodule Statsig.MixProject do
 
   # Run "mix help compile.app" to learn about applications.
   def application do
-    case Mix.env() do
-      :test ->
-        [extra_applications: [:logger, :jason]]
-      _ ->
-        [
-          mod: {Statsig.Application, []},
-          extra_applications: [:logger, :jason]
-        ]
-    end
+    [
+      mod: {Statsig.Application, []},
+      extra_applications: [:logger]
+    ]
   end
 
   # Specifies which paths to compile per environment.
-  defp elixirc_paths(:test), do: ["lib", "test/support", "test/statsig"]
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
       {:req, "~> 0.5"},
-      {:jason, "~> 1.2"},
       {:ua_parser, "~> 1.8"}
     ]
+  end
+
+  defp aliases() do
+    [test: "test --no-start"]
   end
 end

--- a/test/statsig/user_test.exs
+++ b/test/statsig/user_test.exs
@@ -35,11 +35,10 @@ defmodule Statsig.UserTest do
 
   describe "JSON serialization" do
     test "excludes private_attributes when encoding to JSON" do
-      user = User.new(%{
-        "user_id" => "123",
-        "email" => "test@example.com",
-        "private_attributes" => %{"secret" => "value"}
-      })
+      user = User.new("123", [
+        email: "test@example.com",
+        private_attributes: %{"secret" => "value"}
+      ])
 
       json = Jason.encode!(user)
       decoded = Jason.decode!(json)
@@ -50,17 +49,16 @@ defmodule Statsig.UserTest do
     end
 
     test "includes all other fields when encoding to JSON" do
-      user = User.new(%{
-        "user_id" => "123",
-        "email" => "test@example.com",
-        "custom" => %{"is_employee" => true},
-        "custom_ids" => [employee_id: "456"],
-        "ip" => "1.2.3.4",
-        "user_agent" => "Mozilla",
-        "country" => "US",
-        "locale" => "en-US",
-        "app_version" => "1.0.0"
-      })
+      user = User.new("123", [
+        email: "test@example.com",
+        custom: %{"is_employee" => true},
+        custom_ids: [employee_id: "456"],
+        ip: "1.2.3.4",
+        user_agent: "Mozilla",
+        country: "US",
+        locale: "en-US",
+        app_version: "1.0.0"
+      ])
 
       json = Jason.encode!(user)
       decoded = Jason.decode!(json)

--- a/test/statsig/user_test.exs
+++ b/test/statsig/user_test.exs
@@ -15,20 +15,28 @@ defmodule Statsig.UserTest do
       assert user.email == "test@example.com"
     end
 
-    test "accepts custom_ids list as first argument" do
-      user = User.new([employee_id: "456"])
-      assert user.custom_ids == [employee_id: "456"]
+    test "accepts custom_ids map as first argument" do
+      user = User.new(%{employee_id: "456"})
+      assert user.custom_ids == %{employee_id: "456"}
     end
 
     test "accepts custom_ids with additional params" do
-      user = User.new([employee_id: "456"], email: "test@example.com")
-      assert user.custom_ids == [employee_id: "456"]
+      user = User.new(%{employee_id: "456"}, email: "test@example.com")
+      assert user.custom_ids == %{employee_id: "456"}
       assert user.email == "test@example.com"
     end
 
     test "raises when neither user_id nor custom_ids is provided" do
-      assert_raise RuntimeError, "You must provide a user id or custom ids", fn ->
+      assert_raise RuntimeError, "You must provide a user_id or custom_ids", fn ->
+        User.new(nil)
+      end
+
+      assert_raise RuntimeError, "You must provide a user_id or custom_ids", fn ->
         User.new(%{})
+      end
+
+      assert_raise RuntimeError, "You must provide a user_id or custom_ids", fn ->
+        User.new("")
       end
     end
   end
@@ -53,7 +61,7 @@ defmodule Statsig.UserTest do
       user = User.new("123", [
         email: "test@example.com",
         custom: %{"is_employee" => true},
-        custom_ids: [employee_id: "456"],
+        custom_ids: %{employee_id: "456"},
         ip: "1.2.3.4",
         user_agent: "Mozilla",
         country: "US",

--- a/test/statsig/user_test.exs
+++ b/test/statsig/user_test.exs
@@ -43,8 +43,9 @@ defmodule Statsig.UserTest do
       json = Jason.encode!(user)
       decoded = Jason.decode!(json)
 
-      assert decoded["user_id"] == "123"
+      assert decoded["userID"] == "123"
       assert decoded["email"] == "test@example.com"
+      refute Map.has_key?(decoded, "privateAttributes")
       refute Map.has_key?(decoded, "private_attributes")
     end
 
@@ -63,15 +64,15 @@ defmodule Statsig.UserTest do
       json = Jason.encode!(user)
       decoded = Jason.decode!(json)
 
-      assert decoded["user_id"] == "123"
+      assert decoded["userID"] == "123"
       assert decoded["email"] == "test@example.com"
       assert decoded["custom"] == %{"is_employee" => true}
-      assert decoded["custom_ids"] == %{"employee_id" => "456"}
+      assert decoded["customIDs"] == %{"employee_id" => "456"}
       assert decoded["ip"] == "1.2.3.4"
-      assert decoded["user_agent"] == "Mozilla"
+      assert decoded["userAgent"] == "Mozilla"
       assert decoded["country"] == "US"
       assert decoded["locale"] == "en-US"
-      assert decoded["app_version"] == "1.0.0"
+      assert decoded["appVersion"] == "1.0.0"
     end
   end
 end

--- a/test/statsig/user_test.exs
+++ b/test/statsig/user_test.exs
@@ -3,75 +3,77 @@ defmodule Statsig.UserTest do
 
   alias Statsig.User
 
-  describe "new/1" do
-    test "accepts userID as string key" do
-      user = User.new(%{"userID" => "123"})
-      assert user.userID == "123"
+  describe "new/2" do
+    test "accepts string user_id as first argument" do
+      user = User.new("123")
+      assert user.user_id == "123"
     end
 
-    test "accepts userID as atom key" do
-      user = User.new(%{userID: "123"})
-      assert user.userID == "123"
+    test "accepts string user_id with additional params" do
+      user = User.new("123", email: "test@example.com")
+      assert user.user_id == "123"
+      assert user.email == "test@example.com"
     end
 
-    test "accepts customIDs as string key" do
-      user = User.new(%{"customIDs" => %{"employee_id" => "456"}})
-      assert user.customIDs == %{"employee_id" => "456"}
+    test "accepts custom_ids list as first argument" do
+      user = User.new([employee_id: "456"])
+      assert user.custom_ids == [employee_id: "456"]
     end
 
-    test "accepts customIDs as atom key" do
-      user = User.new(%{customIDs: %{"employee_id" => "456"}})
-      assert user.customIDs == %{"employee_id" => "456"}
+    test "accepts custom_ids with additional params" do
+      user = User.new([employee_id: "456"], email: "test@example.com")
+      assert user.custom_ids == [employee_id: "456"]
+      assert user.email == "test@example.com"
     end
 
-    test "raises when neither userID nor customIDs is provided" do
-      assert_raise ArgumentError, "Either userID or customIDs must be provided", fn ->
-        User.new(%{email: "test@example.com"})
+    test "raises when neither user_id nor custom_ids is provided" do
+      assert_raise RuntimeError, "You must provide a user id or custom ids", fn ->
+        User.new(%{})
       end
     end
   end
 
   describe "JSON serialization" do
-    test "excludes privateAttributes when encoding to JSON" do
+    test "excludes private_attributes when encoding to JSON" do
       user = User.new(%{
-        "userID" => "123",
+        "user_id" => "123",
         "email" => "test@example.com",
-        "privateAttributes" => %{"secret" => "value"}
+        "private_attributes" => %{"secret" => "value"}
       })
 
       json = Jason.encode!(user)
       decoded = Jason.decode!(json)
 
-      assert decoded["userID"] == "123"
+      assert decoded["user_id"] == "123"
       assert decoded["email"] == "test@example.com"
-      refute Map.has_key?(decoded, "privateAttributes")
+      refute Map.has_key?(decoded, "private_attributes")
     end
 
     test "includes all other fields when encoding to JSON" do
       user = User.new(%{
-        "userID" => "123",
+        "user_id" => "123",
         "email" => "test@example.com",
         "custom" => %{"is_employee" => true},
-        "customIDs" => %{"employee_id" => "456"},
+        "custom_ids" => [employee_id: "456"],
         "ip" => "1.2.3.4",
-        "userAgent" => "Mozilla",
+        "user_agent" => "Mozilla",
         "country" => "US",
         "locale" => "en-US",
-        "appVersion" => "1.0.0"
+        "app_version" => "1.0.0"
       })
 
       json = Jason.encode!(user)
       decoded = Jason.decode!(json)
 
-      assert decoded["userID"] == "123"
+      assert decoded["user_id"] == "123"
       assert decoded["email"] == "test@example.com"
       assert decoded["custom"] == %{"is_employee" => true}
-      assert decoded["customIDs"] == %{"employee_id" => "456"}
+      assert decoded["custom_ids"] == %{"employee_id" => "456"}
       assert decoded["ip"] == "1.2.3.4"
-      assert decoded["userAgent"] == "Mozilla"
+      assert decoded["user_agent"] == "Mozilla"
       assert decoded["country"] == "US"
       assert decoded["locale"] == "en-US"
-      assert decoded["appVersion"] == "1.0.0"
+      assert decoded["app_version"] == "1.0.0"
     end
   end
 end

--- a/test/statsig/user_test.exs
+++ b/test/statsig/user_test.exs
@@ -1,0 +1,77 @@
+defmodule Statsig.UserTest do
+  use ExUnit.Case
+
+  alias Statsig.User
+
+  describe "new/1" do
+    test "accepts userID as string key" do
+      user = User.new(%{"userID" => "123"})
+      assert user.userID == "123"
+    end
+
+    test "accepts userID as atom key" do
+      user = User.new(%{userID: "123"})
+      assert user.userID == "123"
+    end
+
+    test "accepts customIDs as string key" do
+      user = User.new(%{"customIDs" => %{"employee_id" => "456"}})
+      assert user.customIDs == %{"employee_id" => "456"}
+    end
+
+    test "accepts customIDs as atom key" do
+      user = User.new(%{customIDs: %{"employee_id" => "456"}})
+      assert user.customIDs == %{"employee_id" => "456"}
+    end
+
+    test "raises when neither userID nor customIDs is provided" do
+      assert_raise ArgumentError, "Either userID or customIDs must be provided", fn ->
+        User.new(%{email: "test@example.com"})
+      end
+    end
+  end
+
+  describe "JSON serialization" do
+    test "excludes privateAttributes when encoding to JSON" do
+      user = User.new(%{
+        "userID" => "123",
+        "email" => "test@example.com",
+        "privateAttributes" => %{"secret" => "value"}
+      })
+
+      json = Jason.encode!(user)
+      decoded = Jason.decode!(json)
+
+      assert decoded["userID"] == "123"
+      assert decoded["email"] == "test@example.com"
+      refute Map.has_key?(decoded, "privateAttributes")
+    end
+
+    test "includes all other fields when encoding to JSON" do
+      user = User.new(%{
+        "userID" => "123",
+        "email" => "test@example.com",
+        "custom" => %{"is_employee" => true},
+        "customIDs" => %{"employee_id" => "456"},
+        "ip" => "1.2.3.4",
+        "userAgent" => "Mozilla",
+        "country" => "US",
+        "locale" => "en-US",
+        "appVersion" => "1.0.0"
+      })
+
+      json = Jason.encode!(user)
+      decoded = Jason.decode!(json)
+
+      assert decoded["userID"] == "123"
+      assert decoded["email"] == "test@example.com"
+      assert decoded["custom"] == %{"is_employee" => true}
+      assert decoded["customIDs"] == %{"employee_id" => "456"}
+      assert decoded["ip"] == "1.2.3.4"
+      assert decoded["userAgent"] == "Mozilla"
+      assert decoded["country"] == "US"
+      assert decoded["locale"] == "en-US"
+      assert decoded["appVersion"] == "1.0.0"
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,1 @@
-Statsig.start_link(name: :test)
 ExUnit.start(exclude: [:flakey])


### PR DESCRIPTION
The `StatsigUser` is a core concept within Statsig.  It is essentially a bag of properties related to the context for a) a given gate/config/experiment/layer evaluation or b) an event log. In order to do partial rollouts, an ID is required - either a userID, or a customID.  Read more here: https://docs.statsig.com/server/concepts/user

Previously, the elixir client just used a map for the user.  This makes it a struct

mix test --no-start test/statsig