### PR TITLE
feat: dynamic config struct

### DIFF
--- a/lib/statsig.ex
+++ b/lib/statsig.ex
@@ -22,11 +22,16 @@ defmodule Statsig do
     result = Statsig.Evaluator.eval(user, config, :config)
     log_exposures(user, result, :config)
 
-    # TODO - could probably hand back a Result struct
     case result do
       %{reason: :not_found} -> {:error, :not_found}
-      # TODO - this be {:ok, result}
-      _ -> %{rule_id: Map.get(result.rule, "id"), value: result.value}
+      _ -> {:ok, Statsig.DynamicConfig.new(
+        config,
+        result.value,
+        Map.get(result.rule, "id"),
+        Map.get(result.rule, "groupName"),
+        Map.get(result.rule, "idType"),
+        result.exposures
+      )}
     end
   end
 

--- a/lib/statsig/dynamic_config.ex
+++ b/lib/statsig/dynamic_config.ex
@@ -1,0 +1,36 @@
+defmodule Statsig.DynamicConfig do
+  @type secondary_exposure :: %{
+    gate: String.t(),
+    gateValue: String.t(),
+    ruleID: String.t()
+  }
+
+  @type t :: %__MODULE__{
+    name: String.t(),
+    value: map(),
+    rule_id: String.t(),
+    group_name: String.t() | nil,
+    id_type: String.t() | nil,
+    secondary_exposures: [secondary_exposure()]
+  }
+
+  defstruct [
+    :name,
+    :value,
+    :rule_id,
+    :group_name,
+    :id_type,
+    secondary_exposures: []
+  ]
+
+  def new(config_name, value \\ %{}, rule_id \\ "", group_name \\ nil, id_type \\ nil, secondary_exposures \\ []) do
+    %__MODULE__{
+      name: config_name || "",
+      value: value || %{},
+      rule_id: rule_id,
+      group_name: group_name,
+      id_type: id_type,
+      secondary_exposures: secondary_exposures || []
+    }
+  end
+end

--- a/lib/statsig/dynamic_config.ex
+++ b/lib/statsig/dynamic_config.ex
@@ -23,7 +23,22 @@ defmodule Statsig.DynamicConfig do
     secondary_exposures: []
   ]
 
-  def new(config_name, value \\ %{}, rule_id \\ "", group_name \\ nil, id_type \\ nil, secondary_exposures \\ []) do
+  @spec new(
+    String.t(),
+    map(),
+    String.t() | nil,
+    String.t() | nil,
+    String.t() | nil,
+    [secondary_exposure()] | nil
+  ) :: t()
+  def new(
+    config_name,
+    value,
+    rule_id,
+    group_name,
+    id_type,
+    secondary_exposures
+  ) do
     %__MODULE__{
       name: config_name || "",
       value: value || %{},

--- a/lib/statsig/evaluator.ex
+++ b/lib/statsig/evaluator.ex
@@ -80,7 +80,7 @@ defmodule Statsig.Evaluator do
             result
             | result: final_result,
               value: Map.get(rule, "returnValue"),
-              reason: :rule_match
+              reason: :rule_match,
           },
           fn r, final ->
             %EvaluationResult{final | exposures: r.exposures ++ final.exposures}


### PR DESCRIPTION
Adds a struct representing a DynamicConfig.  DynamicConfig is typically a class returned by the `getConfig` and `getExperiment` methods, which has some accessor methods for metadata and convenience methods for getting values from your config.

For now, ive just included metadata and the value

Bonus - this adds support for groupName, and passes the test for consistency with other server sdks:

```
 PASS  ../__tests__/common-rulesets-based/dynamic-config-group-name.test.ts
  Dynamic Config Group Name
    Elixir
      ✓ getConfig + Passes Targeting = null (2 ms)
      ✓ getConfig + default = null (1 ms)
      ✓ getExperiment + In Control Group = Control (1 ms)
      ✓ getExperiment + In Control Group = Test (1 ms)
      ✓ getExperiment + In Control Group = Test2
      ✓ getExperiment + Fail Targeting = null (1 ms)
      ✓ getExperiment + Not Allocated = null (1 ms)
```