### PR TITLE
feat: log rulePassed for dc exposures

### DIFF
--- a/lib/statsig.ex
+++ b/lib/statsig.ex
@@ -46,10 +46,11 @@ defmodule Statsig do
     log_event(event)
   end
 
-  defp log_exposures(user, [%{"gate" => c, "ruleID" => r} | secondary], :config) do
+  defp log_exposures(user, [%{"gate" => c, "ruleID" => r, "gateValue" => v} | secondary], :config) do
     primary = %{
       "config" => c,
-      "ruleID" => r
+      "ruleID" => r,
+      "rulePassed" => v
     }
 
     event =


### PR DESCRIPTION

```
 PASS  ../__tests__/common-rulesets-based/dynamic-config-value.test.ts
  Dynamic Config Value
    Elixir
      ✓ logs config exposure for passing user (153 ms)
      ✓ logs config exposure for failing user (120 ms)
```