### PR TITLE
feat: support configVersion

### DIFF
--- a/lib/statsig/evaluation_result.ex
+++ b/lib/statsig/evaluation_result.ex
@@ -1,0 +1,9 @@
+defmodule Statsig.EvaluationResult do
+  defstruct exposures: [],
+            secondary_exposures: [],
+            raw_result: false,
+            result: false,
+            reason: nil,
+            rule: %{},
+            value: nil
+end


### PR DESCRIPTION
```
 PASS  ../__tests__/common-rulesets-based/exposure-config-version.test.ts
  Exposure Config Version
    Elixir
      ✓ logs gate exposure with version (174 ms)
      ✓ logs config exposure with version (119 ms)
      ○ skipped logs layer exposure with version
```