### PR TITLE
fix: evaluation

### DIFF
--- a/lib/statsig/user.ex
+++ b/lib/statsig/user.ex
@@ -30,9 +30,6 @@ defmodule Statsig.User do
   end
 
   def new(user_id, params) when is_binary(user_id) do
-    if String.trim(user_id) == "" do
-      raise "You must provide a user_id or custom_ids"
-    end
     struct(__MODULE__, Keyword.merge(params, user_id: user_id))
   end
 


### PR DESCRIPTION
Rulesets test failed without these fixes:

1. configVersion only on primary exposures
2. userID can be empty string
3. eq/neq evaluation
4. always check custom/private if top level unset

```
Test Suites: 15 skipped, 16 passed, 16 of 31 total
Tests:       137 skipped, 28850 passed, 28987 total
```