### PR TITLE
feat: bootstrap and timeout initialization

### DIFF
--- a/lib/statsig/api_client.ex
+++ b/lib/statsig/api_client.ex
@@ -3,7 +3,7 @@ defmodule Statsig.APIClient do
   @default_logging_api_url "https://statsigapi.net/v1"
   @default_config_specs_api_url "https://api.statsigcdn.com/v1"
 
-  def download_config_specs(since_time \\ 0) do
+  def download_config_specs(since_time \\ 0, timeout \\ nil) do
     case api_key() do
       {:ok, key} ->
         base_url = api_url(@default_config_specs_api_url)
@@ -14,7 +14,10 @@ defmodule Statsig.APIClient do
           |> URI.append_query(URI.encode_query(sinceTime: to_string(since_time)))
           |> URI.to_string()
 
-        case Req.get(url: url, headers: headers(key)) do
+        request_opts = [url: url, headers: headers(key)]
+        request_opts = if timeout, do: Keyword.put(request_opts, :receive_timeout, timeout), else: request_opts
+
+        case Req.get(request_opts) do
           {:ok, %Req.Response{status: status, body: %{} = body}} when status in 200..299 ->
             {:ok, body}
 

--- a/lib/statsig/configs.ex
+++ b/lib/statsig/configs.ex
@@ -3,9 +3,11 @@ defmodule Statsig.Configs do
   require Logger
 
   @table_name :statsig_configs
-  @default_reload_interval :timer.seconds(10)
+  @default_init_timeout :timer.seconds(5)
 
   defmodule State do
+    @default_reload_interval :timer.seconds(10)
+
     @type t :: %__MODULE__{
             last_sync_time: integer(),
             reload_timer: reference() | nil,
@@ -17,10 +19,14 @@ defmodule Statsig.Configs do
               reload_interval: @default_reload_interval
 
     def new() do
-      %__MODULE__{reload_interval: reload_interval()}
+      interval = reload_interval()
+      %__MODULE__{reload_interval: interval}
     end
 
     def schedule_reload(%__MODULE__{} = state) do
+      if state.reload_timer != nil do
+        Process.cancel_timer(state.reload_timer)
+      end
       timer = Process.send_after(self(), :reload_configs, state.reload_interval)
       %__MODULE__{state | reload_timer: timer}
     end
@@ -41,9 +47,12 @@ defmodule Statsig.Configs do
   @impl true
   def init(_) do
     :ets.new(@table_name, [:named_table, :set, :public])
-    initial_state = State.new()
+    initial_state = case init_from_bootstrap() do
+      {:ok, bootstrap_state} -> bootstrap_state
+      :skip -> State.new()
+    end
 
-    case attempt_reload(initial_state) do
+    case attempt_reload(initial_state, init_timeout()) do
       {:ok, updated_state} -> {:ok, State.schedule_reload(updated_state)}
       {:error, _error} -> {:ok, State.schedule_reload(initial_state)}
     end
@@ -57,17 +66,20 @@ defmodule Statsig.Configs do
     end
   end
 
-  defp reload_configs(state) do
-    case api_client().download_config_specs(state.last_sync_time) do
+  defp reload_configs(state, timeout) do
+    case api_client().download_config_specs(state.last_sync_time, timeout) do
       {:ok, response} ->
         new_time = Map.get(response, "time", 0)
 
         if new_time >= state.last_sync_time do
-          :ets.delete_all_objects(@table_name)
-          response |> Map.get("feature_gates", []) |> update_configs(:gate)
-          response |> Map.get("dynamic_configs", []) |> update_configs(:config)
-
-          {:ok, %{state | last_sync_time: new_time}}
+          try do
+            update_specs(response)
+            {:ok, %{state | last_sync_time: new_time}}
+          rescue
+            error ->
+              Logger.error("Failed to update specs: #{inspect(error)}")
+              {:ok, state}
+          end
         else
           {:ok, state}
         end
@@ -77,18 +89,14 @@ defmodule Statsig.Configs do
     end
   end
 
-  defp attempt_reload(state) do
-    case reload_configs(state) do
+  defp attempt_reload(state, timeout \\ :infinity) do
+    case reload_configs(state, timeout) do
       {:ok, updated_state} ->
         {:ok, updated_state}
       {:error, error} ->
         Logger.error("Unexpected error while reloading Statsig configs: #{inspect(error)}")
         {:error, {:reload_failed, error}}
     end
-  end
-
-  defp reload_interval() do
-    Application.get_env(:statsig, :config_reload_interval, 10_000)
   end
 
   defp update_configs([], _type), do: :ok
@@ -99,4 +107,32 @@ defmodule Statsig.Configs do
   end
 
   defp api_client, do: Application.get_env(:statsig, :api_client, Statsig.APIClient)
+
+  defp init_from_bootstrap() do
+    case Application.get_env(:statsig, :bootstrap_config_specs) do
+      nil ->
+        :skip
+      specs when is_map(specs) ->
+        time = update_specs(specs)
+        {:ok, %{State.new() | last_sync_time: time}}
+      other ->
+        Logger.warning("Invalid bootstrap_config_specs format, falling back to network initialization")
+        :skip
+    end
+  end
+
+  defp update_specs(specs) do
+    time = Map.get(specs, "time", 0)
+    :ets.delete_all_objects(@table_name)
+
+    Map.get(specs, "feature_gates", [])
+    |> update_configs(:gate)
+    Map.get(specs, "dynamic_configs", [])
+    |> update_configs(:config)
+    time
+  end
+
+  defp init_timeout() do
+    Application.get_env(:statsig, :config_init_timeout, @default_init_timeout)
+  end
 end

--- a/test/statsig/bootstrap_test.exs
+++ b/test/statsig/bootstrap_test.exs
@@ -1,0 +1,46 @@
+defmodule Statsig.BootstrapTest do
+  use ExUnit.Case
+
+  @moduletag :capture_log
+
+  setup do
+    # Stop the application if it's running
+    Application.stop(:statsig)
+
+    # Read and set bootstrap data
+    bootstrap_data =
+      "test/data/rulesets_e2e_config.json"
+      |> File.read!()
+      |> Jason.decode!()
+
+    Application.put_env(:statsig, :bootstrap_config_specs, bootstrap_data)
+
+    # Now start the application with bootstrap data in place
+    start_supervised!(%{
+      id: Statsig.Application,
+      start: {Statsig.Application, :start, [:normal, []]}
+    })
+
+    on_exit(fn ->
+      Application.delete_env(:statsig, :bootstrap_config_specs)
+    end)
+
+    :ok
+  end
+
+  test "uses bootstrapped gate values" do
+    {:ok, result} = Statsig.check_gate(%Statsig.User{user_id: "12345"}, "test_numeric_user_id")
+    assert result == true
+  end
+
+  test "uses bootstrapped config values" do
+    {:ok, result} = Statsig.get_config(%Statsig.User{user_id: "123", email: "jkw@statsig.com"}, "test_email_config")
+
+    assert %Statsig.DynamicConfig{
+      value: %{
+        "header_text" => "jkw only"
+      }
+    } = result
+  end
+
+end


### PR DESCRIPTION
There are two main pieces missing to initialization to make this more robust.  We dont want to block application startup because of a) a network request taking too long or b) failure to initialize statsig.

This adds two configuration options:

1. an initialization timeout
2. a bootstrap spec

To address this. Bootstrapping will still attempt to sync from the network